### PR TITLE
Route enhancement: /file for non soft deleted and /file/recycle-bin for soft deleted file

### DIFF
--- a/src/routes/file.py
+++ b/src/routes/file.py
@@ -13,7 +13,11 @@ router = APIRouter()
 
 @router.get("/file")
 def get_uploaded_files(db: Annotated[Session, Depends(get_db)]):
-    return db.query(models.File).all()
+    return db.query(models.File).filter(models.File.deleted_at == None).all()
+
+@router.get("/file/recycle-bin")
+def get_uploaded_files(db: Annotated[Session, Depends(get_db)]):
+    return db.query(models.File).filter(models.File.deleted_at != None).all()
 
 @router.get("/file/{file_id}")
 def download_file(file_id: str, discord: Annotated[DiscordService, Depends(get_discord)], db: Annotated[Session, Depends(get_db)]):


### PR DESCRIPTION
Feature request:
a separated route for soft deleted and non soft deleted files

**Done**
1. Filter `/file` route to only show files that has `None` as their `deleted_at` attribute
2. Create new route `/file/recycle-bin` to only show files that has `deleted_at` attribute
